### PR TITLE
Fix make clean and split compile/link steps

### DIFF
--- a/vhdl_vpi/Makefile
+++ b/vhdl_vpi/Makefile
@@ -1,7 +1,8 @@
 VHDL_FILES = assets/app.vhdl 	# all vhdl files to analyze
 EXEC_TOP_UNIT = up_counter 		# top entity name
 
-SRC		= $(shell find ./src/ -name "*.cpp")
+SRC=$(shell find ./src/ -name "*.cpp")
+OBJ=$(SRC:.cpp=.o )
 INCLUDE = src
 LIB		= 
 BUILD   = build
@@ -17,14 +18,20 @@ INCLUDEFLAG = -I$(INCLUDE) -I$(INCLUDE)/assignments_cfg
 
 GHDL     = ghdl
 GHDLLD   = $(GHDL) --vpi-link $(CXX)
+GHDLC   = $(GHDL) --vpi-compile $(CXX)
 
 all: $(BUILD)/$(TARGET)
 
 pch: src/pch.hpp
 	$(CXX) src/pch.hpp
 
+%.o: %.cpp
+	$(GHDLC) $(CXXFLAGS) $(INCLUDEFLAG) -c $^ -o $@
+
+compile: $(OBJ)
+
 # TODO: recompile if headers are changed
-$(BUILD)/$(TARGET): $(SRC)
+$(BUILD)/$(TARGET): $(OBJ)
 	$(GHDLLD) $(CXXFLAGS) $(INCLUDEFLAG) $^ -o $@ $(LIBRARIES)
 
 exec: $(BUILD)/$(TARGET)
@@ -33,7 +40,6 @@ exec: $(BUILD)/$(TARGET)
 	$(GHDL) -r -fsynopsys $(EXEC_TOP_UNIT) --vpi=./$(BUILD)/$(TARGET)
 
 clean:
-	@rm $(BIN)/*
+	@rm $(BUILD)/*
 	@rm -vf work-*.cf
 	@rm -vf *.o
-


### PR DESCRIPTION
make clean referenced BIN instead of BUILD, almost wiping out my whole
disk. Not cool.

Instead of doing the compilation and linking in a single step, this
changes the Makefile to compile each .cpp individually and then link
them all together in a separate step.